### PR TITLE
fix(gallery): enable scrolling from within image content

### DIFF
--- a/Camera/View/GalleryView.swift
+++ b/Camera/View/GalleryView.swift
@@ -144,20 +144,22 @@ struct GalleryView: View {
                             }
                         }
                         .coordinateSpace(name: "photoGrid")
-                        .gesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { value in
-                                    if activeSessionDrag == nil {
-                                        activeSessionDrag = item.session
+                        .if(isMultiSelectMode) {
+                            $0.gesture(
+                                DragGesture(minimumDistance: 0)
+                                    .onChanged { value in
+                                        if activeSessionDrag == nil {
+                                            activeSessionDrag = item.session
+                                        }
+                                        self.dragLocation = value.location
                                     }
-                                    self.dragLocation = value.location
-                                }
-                                .onEnded { _ in
-                                    self.dragLocation = nil
-                                    self.alreadySelectedDuringDrag.removeAll()
-                                    self.activeSessionDrag = nil
-                                }
-                        )
+                                    .onEnded { _ in
+                                        self.dragLocation = nil
+                                        self.alreadySelectedDuringDrag.removeAll()
+                                        self.activeSessionDrag = nil
+                                    }
+                            )
+                        }
                         .padding()
                     }
                     
@@ -488,4 +490,14 @@ struct GalleryView: View {
     }
 
 
+}
+
+extension View {
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
 }


### PR DESCRIPTION
Fixes a bug where scrolling in the gallery was not possible when the gesture started directly on an image.
This was caused by the drag gesture for multi-selection interfering with the scroll view's gesture recognition.

The fix wraps the drag gesture in a conditional modifier so that it is only active when the gallery is in 'Select' mode.
This allows the scroll view to handle touch events normally outside of selection mode, enabling a smoother and more intuitive user experience.