### PR TITLE
fix(gallery): enable vertical scrolling in multi-select mode

### DIFF
--- a/Camera/View/GalleryView.swift
+++ b/Camera/View/GalleryView.swift
@@ -145,13 +145,17 @@ struct GalleryView: View {
                         }
                         .coordinateSpace(name: "photoGrid")
                         .if(isMultiSelectMode) {
-                            $0.gesture(
+                            $0.simultaneousGesture(
                                 DragGesture(minimumDistance: 0)
                                     .onChanged { value in
-                                        if activeSessionDrag == nil {
-                                            activeSessionDrag = item.session
+                                        let horizontalDistance = abs(value.translation.width)
+                                        let verticalDistance = abs(value.translation.height)
+                                        if horizontalDistance > verticalDistance {
+                                            if activeSessionDrag == nil {
+                                                activeSessionDrag = item.session
+                                            }
+                                            self.dragLocation = value.location
                                         }
-                                        self.dragLocation = value.location
                                     }
                                     .onEnded { _ in
                                         self.dragLocation = nil


### PR DESCRIPTION
Fixes a bug in the gallery's multi-selection mode where vertical scrolling was disabled. The previous implementation used a gesture modifier that interfered with the ScrollView's ability to handle vertical gestures.

The fix replaces the gesture modifier with simultaneousGesture, allowing both the custom drag gesture for horizontal photo selection and the ScrollView's internal gesture recognizer to work together. As a result, users can now scroll vertically without unintentionally selecting photos, while horizontal swiping still correctly triggers selection, leading to a more intuitive and user-friendly experience.