### PR TITLE
feat: update camera permission message and localize text

### DIFF
--- a/Camera/View/CheckCamera.swift
+++ b/Camera/View/CheckCamera.swift
@@ -18,7 +18,7 @@ struct ShowCamera: View {
             case .denied:
                 CameraPermissionView()
             case .notDetermined:
-                Text("Memeriksa izin kamera...")
+                Text("Checking camera permissions...")
             }
         }
         .onAppear {

--- a/Snaptify.xcodeproj/project.pbxproj
+++ b/Snaptify.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Camera/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Snaptify;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				INFOPLIST_KEY_NSCameraUsageDescription = "We need access to your camera to take photos.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Snaptify uses your camera to detect your smile and take photos";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "test value";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -454,7 +454,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Camera/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Snaptify;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				INFOPLIST_KEY_NSCameraUsageDescription = "We need access to your camera to take photos.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Snaptify uses your camera to detect your smile and take photos";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "test value";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
This commit introduces two user-facing improvements:

- Updated the camera permission prompt to clearly explain that the app uses the camera to detect smiles and capture photos, providing better context for the user.
- Localized the text displayed while checking camera permissions to English for consistency.